### PR TITLE
Update gson proguard config

### DIFF
--- a/proguard/proguard-gson.pro
+++ b/proguard/proguard-gson.pro
@@ -1,20 +1,48 @@
-# Gson
+# Keep generic signatures; needed for correct type resolution
 -keepattributes Signature
 
-# For using GSON @Expose annotation
+# Keep Gson annotations
+# Note: Cannot perform finer selection here to only cover Gson annotations, see also https://stackoverflow.com/q/47515093
 -keepattributes *Annotation*
 
-# Gson specific classes
--dontwarn sun.misc.**
 
-# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
-# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
--keep class * extends com.google.gson.TypeAdapter
--keep class * implements com.google.gson.TypeAdapterFactory
--keep class * implements com.google.gson.JsonSerializer
--keep class * implements com.google.gson.JsonDeserializer
+### The following rules are needed for R8 in "full mode" which only adheres to `-keepattribtues` if
+### the corresponding class or field is matches by a `-keep` rule as well, see
+### https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#r8-full-mode
 
-# Prevent R8 from leaving Data object members always null
+# Keep class TypeToken (respectively its generic signature)
+-keep class com.google.gson.reflect.TypeToken { *; }
+
+# Keep any (anonymous) classes extending TypeToken
+-keep class * extends com.google.gson.reflect.TypeToken
+
+# Keep classes with @JsonAdapter annotation
+-keep @com.google.gson.annotations.JsonAdapter class *
+
+# Keep fields with @SerializedName annotation, but allow obfuscation of their names
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;
+}
+
+# Keep fields with any other Gson annotation
+-keepclassmembers class * {
+  @com.google.gson.annotations.Expose <fields>;
+  @com.google.gson.annotations.JsonAdapter <fields>;
+  @com.google.gson.annotations.Since <fields>;
+  @com.google.gson.annotations.Until <fields>;
+}
+
+# Keep no-args constructor of classes which can be used with @JsonAdapter
+# By default their no-args constructor is invoked to create an adapter instance
+-keep class * extends com.google.gson.TypeAdapter {
+  <init>();
+}
+-keep class * implements com.google.gson.TypeAdapterFactory {
+  <init>();
+}
+-keep class * implements com.google.gson.JsonSerializer {
+  <init>();
+}
+-keep class * implements com.google.gson.JsonDeserializer {
+  <init>();
 }


### PR DESCRIPTION
AGP 8.0.0+ более агрессивно использует R8, и с текущими правилами касатально GSON будет обфусцирован IdsAdapter.
В следствии чего можно получить следующий json:
{"viewProductCategory":{"productCategory":{"ids":{"ids":{"systemId":"723"}}}}}

Полагаю, consumer-rules стоит обновить, или хотя бы добавить 
-keep @com.google.gson.annotations.JsonAdapter class *