### PR TITLE
WMSDK-450: Fix distribution and tests

### DIFF
--- a/.github/workflows/distribute-develop-mission.yml
+++ b/.github/workflows/distribute-develop-mission.yml
@@ -1,9 +1,10 @@
-name: PushOk (Develop PR Merge)
+name: PushOk (Develop / Mission PR Merge)
 
 on:
   pull_request:
     branches:
       - develop
+      - mission/*
     types:
       - closed
 

--- a/.github/workflows/lint_unitTests_build.yml
+++ b/.github/workflows/lint_unitTests_build.yml
@@ -1,20 +1,13 @@
 name: Lint + UnitTests + Build
 
 on:
-  push:
-    branches:
-      - '**'
-      - '!master'
-    paths-ignore:
-      - '**.md'
-    tags-ignore:
-      - '**'
   pull_request:
     branches:
       - master
       - mission/*
     types:
       - opened
+      - synchronize
 
 jobs:
   lint:

--- a/.github/workflows/lint_unitTests_build.yml
+++ b/.github/workflows/lint_unitTests_build.yml
@@ -2,11 +2,9 @@ name: Lint + UnitTests + Build
 
 on:
   pull_request:
-    branches:
-      - master
-      - mission/*
     types:
       - opened
+      - reopened
       - synchronize
 
 jobs:


### PR DESCRIPTION
PushOk будет собираться на закрытие PR в mission, как фичи на develop

Тесты будут прогоняться только в открытых PR, чтобы не дублировать логику на пуш [прецедент](https://github.com/mindbox-cloud/android-sdk/pull/590)